### PR TITLE
chore: update primevue to 3.53

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "postcss": "^8.4.31",
         "postcss-preset-env": "^7.8.3",
         "primeicons": "^6.0.1",
-        "primevue": "^3.42.0",
+        "primevue": "3.53",
         "sass": "^1.54.9",
         "tailwindcss": "^3.3.3",
         "typescript": "~5.2.0",
@@ -4504,9 +4504,9 @@
       "dev": true
     },
     "node_modules/primevue": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.42.0.tgz",
-      "integrity": "sha512-vY/nHBInl/k2MFfgx+5dGI3tH1P6OmO2Oj6eOLwtHk000yopPxLBUP/enALoElriy5EaPzfv02upOrsQqd+nJA==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.53.0.tgz",
+      "integrity": "sha512-mRqTPGGZX+3AQokaCCjxLVSNEjGEA7LaPdBT4qSpGEdMstK6vhUBCxgLH7IPjHudbaSi4Xo3CIO62pXQxbz8dQ==",
       "dev": true,
       "peerDependencies": {
         "vue": "^3.0.0"
@@ -8308,9 +8308,9 @@
       "dev": true
     },
     "primevue": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.42.0.tgz",
-      "integrity": "sha512-vY/nHBInl/k2MFfgx+5dGI3tH1P6OmO2Oj6eOLwtHk000yopPxLBUP/enALoElriy5EaPzfv02upOrsQqd+nJA==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/primevue/-/primevue-3.53.0.tgz",
+      "integrity": "sha512-mRqTPGGZX+3AQokaCCjxLVSNEjGEA7LaPdBT4qSpGEdMstK6vhUBCxgLH7IPjHudbaSi4Xo3CIO62pXQxbz8dQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "postcss": "^8.4.31",
     "postcss-preset-env": "^7.8.3",
     "primeicons": "^6.0.1",
-    "primevue": "^3.42.0",
+    "primevue": "3.53",
     "sass": "^1.54.9",
     "tailwindcss": "^3.3.3",
     "typescript": "~5.2.0",


### PR DESCRIPTION
As mentioned in #101, for using the FloatLabel Component, the PrimeVue version needs to be `>= 3.48`. This PR updates PrimeVue to the newest version. 

The theme didn't need to be changed, as it only got deprecated as it won't be avaivable in versions `>= 4.0`. I don't think we will have to upgrade to v4 anytime soon.